### PR TITLE
Add props to set dynamic CSS classes on table cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ For other examples, see [the demo folder](https://github.com/aminya/solid-simple
   headerRenderer?(column: Column): string | Renderable
   bodyRenderer?(row: Row, columnID: K): string | Renderable
 
+  // dynamic CSS classes for table cells
+  headerCellClass?(column: Column): string
+  bodyCellClass?(row: Row, columnID: K): string
+
   // the class name to be used instead of the provided default. The default value is `solid-simple-table light typography`
   className?: string
   // extra styles

--- a/src/SimpleTable.tsx
+++ b/src/SimpleTable.tsx
@@ -58,6 +58,8 @@ export function SimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>
     headerRenderer = defaultHeaderRenderer,
     bodyRenderer = defaultBodyRenderer,
     getRowID = defaultGetRowID,
+    headerCellClass,
+    bodyCellClass,
     accessors,
   } = props
 
@@ -88,6 +90,7 @@ export function SimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>
               const isSortable = column.sortable !== false
               return (
                 <th
+                  class={headerCellClass?.(column)}
                   id={accessors === true ? String(column.id) : undefined}
                   className={isSortable ? "sortable" : undefined}
                   onClick={isSortable ? generateSortCallback(column.id) : undefined}
@@ -110,6 +113,7 @@ export function SimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>
                   {(column) => {
                     return (
                       <td
+                        class={bodyCellClass?.(row, column.id)}
                         onClick={column.onClick !== undefined ? (e: MouseEvent) => column.onClick!(e, row) : undefined}
                         id={rowID !== undefined ? `${rowID}.${column.id}` : undefined}
                       >

--- a/src/SimpleTable.types.ts
+++ b/src/SimpleTable.types.ts
@@ -47,6 +47,10 @@ export type Props<K extends IndexType> = {
   headerRenderer?(column: Column): string | Renderable
   bodyRenderer?(row: Row<K>, columnID: K): string | Renderable
 
+  // dynamic CSS classes
+  headerCellClass?(column: Column): string
+  bodyCellClass?(row: Row<K>, columnID: K): string
+
   // styles
   style?: JSX.CSSProperties | string
   className?: string


### PR DESCRIPTION
This PR adds two optional props to `SimpleTable` for dynamic table cell CSS classes:

### `headerCellClass`

Optional function to get dynamic CSS class names for each column header cell.
_Params:_ `Column` object (same as for `headerRenderer`)
_Returns:_ `string` of CSS class names to be set for the `th` element of that column

### `bodyCellClass`

Optional function to get dynamic CSS class names for each body cell.
_Params:_ `Row` object, column ID (same as for `bodyRenderer`)
_Returns:_ `string` of CSS class names to be set for that cell's `td` element