### PR TITLE
Ability to pass id prop to whole table

### DIFF
--- a/demo/complex/index.tsx
+++ b/demo/complex/index.tsx
@@ -1,6 +1,7 @@
 import { render } from "solid-js/web"
 import { SimpleTable } from "../../src/SimpleTable"
 import type { NonNullSortDirection } from "../../src/SimpleTable"
+import type { IndexType, Props } from "../../src/SimpleTable"
 
 export const rows = [
   { file: "C:/a", message: "Lorem ipsum dolor sit amet, consectetur", severity: "error" },
@@ -47,7 +48,7 @@ function MyComplexTableSorter(
   })
 }
 
-export function MyComplexTable() {
+export function MyComplexTable<Ind extends IndexType = IndexType>(props: Props<Ind>) {
   return (
     <SimpleTable
       rows={rows}
@@ -57,6 +58,7 @@ export function MyComplexTable() {
       defaultSortDirection={["file", "asc"]}
       rowSorter={MyComplexTableSorter}
       getRowID={(row) => JSON.stringify(row)}
+      id={props.id}
     />
   )
 }

--- a/demo/simple/index.tsx
+++ b/demo/simple/index.tsx
@@ -1,5 +1,6 @@
 import { render } from "solid-js/web"
 import { SimpleTable } from "../../src/SimpleTable"
+import type { IndexType, Props } from "../../src/SimpleTable"
 
 export const rows = [
   { file: "C:/a", message: "Lorem ipsum dolor sit amet, consectetur", severity: "error" },
@@ -8,8 +9,8 @@ export const rows = [
   { file: "C:/d", message: "Cras faucibus eget ante ut consectetur", severity: "error" },
 ]
 
-export function MySimpleTable() {
-  return <SimpleTable rows={rows} />
+export function MySimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>) {
+  return <SimpleTable rows={rows} id={props.id}/>
 }
 
 // skip rendering if in test mode

--- a/src/SimpleTable.tsx
+++ b/src/SimpleTable.tsx
@@ -82,7 +82,11 @@ export function SimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>
   sortRows()
 
   return (
-    <table className={props.className ?? "solid-simple-table light typography"} style={props.style}>
+    <table 
+      className={props.className ?? "solid-simple-table light typography"} 
+      style={props.style} 
+      {...(props?.id ? {id: props.id} : {})}
+    >
       <thead>
         <tr>
           <For each={props.columns!}>

--- a/src/SimpleTable.tsx
+++ b/src/SimpleTable.tsx
@@ -84,7 +84,7 @@ export function SimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>
 
   return (
     <table
-      className={props.className ?? "solid-simple-table light typography"}
+      class={props.className ?? "solid-simple-table light typography"}
       style={props.style}
       id={id ?? undefined}
     >

--- a/src/SimpleTable.tsx
+++ b/src/SimpleTable.tsx
@@ -61,6 +61,7 @@ export function SimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>
     headerCellClass,
     bodyCellClass,
     accessors,
+    id
   } = props
 
   function maybeRowID(row: Row<Ind>) {
@@ -82,10 +83,10 @@ export function SimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>
   sortRows()
 
   return (
-    <table 
-      className={props.className ?? "solid-simple-table light typography"} 
-      style={props.style} 
-      {...(props?.id ? {id: props.id} : {})}
+    <table
+      className={props.className ?? "solid-simple-table light typography"}
+      style={props.style}
+      id={id ?? undefined}
     >
       <thead>
         <tr>

--- a/src/SimpleTable.types.ts
+++ b/src/SimpleTable.types.ts
@@ -65,6 +65,7 @@ export type Props<K extends IndexType> = {
 
   // styles
   style?: JSX.CSSProperties | string
+  id?: string
   className?: string
 
   // sort options

--- a/test/SimpleTable.test.tsx
+++ b/test/SimpleTable.test.tsx
@@ -218,6 +218,26 @@ describe("SolidSimpleTable", () => {
     testTable(myComplexTableRows, rootElm, false, MyComplexTableColumns, ["file", "asc"])
   })
 
+  const testIdPropPassing = (expectedId: string) => {
+    const tableElement = rootElm.querySelector("table");
+    expect(tableElement).not.toBeNull();
+    expect(tableElement?.id).toBe(expectedId);
+  };
+
+  test("passes id prop to simple table element", () => {
+    const testId = 'simpletablewithid';
+    dispose = render(() => <MySimpleTable id={testId}/>, rootElm);
+    testIdPropPassing(testId);
+    testTable(mySimpleTableRows, rootElm);
+  });
+
+  test("passes id prop to complex table element", () => {
+    const testId = 'complextablewithid';
+    dispose = render(() => <MyComplexTable id={testId}/>, rootElm);
+    testTable(myComplexTableRows, rootElm, false, MyComplexTableColumns, ["file", "asc"])
+    testIdPropPassing(testId);
+  })
+
   afterEach(() => {
     rootElm.textContent = ""
     dispose()


### PR DESCRIPTION
Hello!

Thanks for Your awesome library! :+1: 
I've been working with it lately and noticed that there wasn't a way to assing a global `id` attribute via `props` to the whole table, since it wasn't being deconstructed within `SimpleTable<Ind extends IndexType = IndexType>(props: Props<Ind>)` function in `SimpleTable.tsx`.

Therefore, I propose adding this feature since it is always awesome to be able to query things via unique `id`s e.g. during tests of DOM manipulations :smile: 

Lemme know if You agree with my idea and/or styling of this new section of code.

Best regards :pray: 