### PR TITLE
Bump @parcel/transformer-less to fix failing build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@parcel/core": "^2.8.0",
     "@parcel/optimizer-esbuild": "^2.8.0",
     "@parcel/packager-ts": "2.8.0",
-    "@parcel/transformer-less": "2.8.0",
+    "@parcel/transformer-less": "2.10.3",
     "@parcel/transformer-typescript-types": "2.8.0",
     "@types/chance": "^1.1.3",
     "@types/jest": "^29.2.2",


### PR DESCRIPTION
Upgrade @parcel/transformer-less to 2.10.3 to fix an issue causing the build to fail

```
@parcel/package-manager: Could not find module "@parcel/transformer-less" satisfying 2.10.3.

  /Users/SilentRhetoric/Code/Forks/solid-simple-table/package.json:59:5
    58 |     "@parcel/packager-ts": "2.8.0",
  > 59 |     "@parcel/transformer-less": "2.8.0",
  >    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Found this conflicting local requirement.
    60 |     "@parcel/transformer-typescript-types": "2.8.0",
    61 |     "@types/chance": "^1.1.3",
```